### PR TITLE
Update UsermodeMemory.cpp

### DIFF
--- a/Nemesis/ProcessUtils.cpp
+++ b/Nemesis/ProcessUtils.cpp
@@ -291,7 +291,7 @@ auto ProcessUtils::GetMemoryList(const DWORD process_id) -> std::vector<MemoryEl
 	// Open the process
 	//
 	const auto process_handle = OpenProcess(PROCESS_ALL_ACCESS, false, process_id);
-	if (process_handle == INVALID_HANDLE_VALUE)
+	if (process_handle == nullptr)
 	{
 		return std::vector<MemoryElement>();
 	}

--- a/Nemesis/ProcessUtils.cpp
+++ b/Nemesis/ProcessUtils.cpp
@@ -167,7 +167,7 @@ auto ProcessUtils::GetModuleListManually(const DWORD process_id) -> std::vector<
 	// Get process handle
 	//
 	const auto process_handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, process_id);
-	if (process_handle == INVALID_HANDLE_VALUE)
+	if (process_handle == nullptr)
 	{
 		Logger::Log("Failed to get process handle.");
 		return std::vector<ModuleElement>();

--- a/Nemesis/UsermodeMemory.cpp
+++ b/Nemesis/UsermodeMemory.cpp
@@ -7,7 +7,7 @@ UsermodeMemory::UsermodeMemory(const DWORD process_id) : IMemorySource(process_i
 {
 	process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, process_id);
 
-	if (process_handle == INVALID_HANDLE_VALUE)
+	if (process_handle == nullptr)
 	{
 		Logger::Log("Failed to open process.");
 	}
@@ -15,7 +15,7 @@ UsermodeMemory::UsermodeMemory(const DWORD process_id) : IMemorySource(process_i
 
 UsermodeMemory::~UsermodeMemory()
 {
-	if (process_handle != INVALID_HANDLE_VALUE)
+	if (process_handle != nullptr)
 	{
 		CloseHandle(process_handle);
 	}
@@ -23,7 +23,7 @@ UsermodeMemory::~UsermodeMemory()
 
 auto UsermodeMemory::ReadMemory(const DWORD_PTR start_address, const SIZE_T size) -> std::shared_ptr<BYTE>
 {
-	if (process_handle == INVALID_HANDLE_VALUE)
+	if (process_handle == nullptr)
 		return nullptr;
 
 	const auto buffer = std::shared_ptr<BYTE>(new BYTE[size], [](const BYTE* memory) {delete[] memory; });
@@ -65,7 +65,7 @@ auto UsermodeMemory::IsValid() -> BOOL
 	//
 	// Check if handle is valid
 	//
-	if (process_handle == INVALID_HANDLE_VALUE)
+	if (process_handle == nullptr)
 	{
 		return FALSE;
 	}

--- a/Nemesis/UsermodeMemory.hpp
+++ b/Nemesis/UsermodeMemory.hpp
@@ -15,7 +15,7 @@ class UsermodeMemory final : public IMemorySource
 	/**
 	 * \brief The process handle.
 	 */
-	HANDLE process_handle = INVALID_HANDLE_VALUE;
+	HANDLE process_handle = nullptr;
 
 public:
 


### PR DESCRIPTION
HANDLES opened by "OpenProcess" do not return "INVALID_HANDLE_VALUE" upon failure, they return NULL (in C++11 we can just use the nullptr keyword)